### PR TITLE
Add the "Lords Mobile" edition of the H950P

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -20,6 +20,21 @@
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T(22d)_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,


### PR DESCRIPTION
The "Lords Mobile" edition of the H950P has a different ProductID than the standard H950P. Adding this identifier allows the "Lords" version to function the same as the standard H950P.